### PR TITLE
Update interface with most recent version of Toolbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ env:
     - TWITTER_CONSUMER_KEY=YOUR_CONSUMER_KEY
     - TWITTER_CONSUMER_SECRET=YOUR_CONSUMER_SECRET
 
-script: coverage run -m unittest discover tests
+script: coverage run -m unittest discover
 after_success: coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.3-alpine
+FROM python:3.6.6-alpine
 
 RUN apk add --no-cache --virtual build-base \
   && apk add --no-cache --virtual libxml2-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ RUN chown -hR serenata_de_amor .
 USER serenata_de_amor
 
 COPY . /usr/src/app
+CMD ["celery", "-A", "whistleblower.tasks", "worker", "-B"]

--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ $ docker-compose up
 ## Testing
 
 ```console
-$ docker-compose run worker python -m unittest discover tests
+$ docker-compose run --rm worker \
+    python -m unittest discover
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ services:
       - 5672:5672
 
   worker:
-    build: .
-    command: celery -A whistleblower.tasks worker -B
+    image: serenata/whistleblower
     restart: always
     depends_on:
       - mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./data:/usr/src/app/data
+      - /tmp/serenata-data:/usr/src/app/data
       - ./rosie:/usr/src/app/rosie
       - ./tests:/usr/src/app/tests
       - ./whistleblower:/usr/src/app/whistleblower

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pandas==0.23.4
 pymongo==3.7.1
 python-twitter==3.4.2
 requests==2.19.1
-serenata-toolbox==12.4.4
+serenata-toolbox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-amqp==2.2.2
-celery==4.1.0
-ipdb==0.10.3
-pandas==0.21.0
-pymongo==3.5.1
-python-twitter==3.3
-requests==2.18.4
-serenata-toolbox==12.2.2
+amqp==2.3.2
+celery==4.2.1
+ipdb==0.11
+pandas==0.23.4
+pymongo==3.7.1
+python-twitter==3.4.2
+requests==2.19.1
+serenata-toolbox==12.4.4

--- a/tests/test_suspicions.py
+++ b/tests/test_suspicions.py
@@ -1,0 +1,19 @@
+import datetime as dt
+from unittest import TestCase, mock
+
+from whistleblower.suspicions import Suspicions as subject_class
+
+
+class TestSuspicions(TestCase):
+    @mock.patch('whistleblower.suspicions.pd')
+    def test_reimbursements(self, pd_mock):
+        path = 'data/reimbursements-{}.csv'
+        subject = subject_class(2010)
+        subject.reimbursements()
+        pd_mock.read_csv.assert_called_with(
+            path.format(2010), dtype=mock.ANY, low_memory=False)
+
+        subject = subject_class()
+        subject.reimbursements()
+        pd_mock.read_csv.assert_called_with(
+            path.format(dt.datetime.today().year), dtype=mock.ANY, low_memory=False)

--- a/tests/test_suspicions.py
+++ b/tests/test_suspicions.py
@@ -5,6 +5,13 @@ from whistleblower.suspicions import Suspicions as subject_class
 
 
 class TestSuspicions(TestCase):
+    @mock.patch.object(subject_class, 'fetch', new_callable=mock.PropertyMock)
+    @mock.patch('whistleblower.suspicions.datasets')
+    @mock.patch('whistleblower.suspicions.pd')
+    def test_all(self, pd_mock, datasets_mock, fetch_mock):
+        subject_class().all()
+        fetch_mock.assert_called_once()
+
     @mock.patch('whistleblower.suspicions.pd')
     def test_reimbursements(self, pd_mock):
         path = 'data/reimbursements-{}.csv'

--- a/whistleblower/queue.py
+++ b/whistleblower/queue.py
@@ -3,8 +3,8 @@ import os
 
 from pymongo import MongoClient
 
-from .suspicions import Suspicions
-from .targets.twitter import Twitter
+from whistleblower.suspicions import Suspicions
+from whistleblower.targets.twitter import Twitter
 import whistleblower.tasks
 
 MONGODB_URI = os.environ.get('MONGODB_URI', 'mongodb://mongo:27017/')

--- a/whistleblower/suspicions.py
+++ b/whistleblower/suspicions.py
@@ -28,6 +28,7 @@ class Suspicions:
         datasets.fetch(self.SOCIAL_ACCOUNTS_FILE, self.data_path)
 
     def all(self):
+        self.fetch()
         dataset = self.reimbursements()
         dataset = dataset.merge(self.__companies(),
                                 how='left',

--- a/whistleblower/suspicions.py
+++ b/whistleblower/suspicions.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import os
 
 import numpy as np
@@ -17,7 +18,8 @@ class Suspicions:
     CONGRESSPEOPLE_FILE = '2017-05-29-deputies.xz'
     SOCIAL_ACCOUNTS_FILE = '2018-02-05-congresspeople-social-accounts.xz'
 
-    def __init__(self, data_path=DATA_PATH):
+    def __init__(self, year=None, data_path=DATA_PATH):
+        self.year = year or dt.datetime.today().year
         self.data_path = data_path
 
     def fetch(self):
@@ -26,7 +28,7 @@ class Suspicions:
         datasets.fetch(self.SOCIAL_ACCOUNTS_FILE, self.data_path)
 
     def all(self):
-        dataset = self.__reimbursements()
+        dataset = self.reimbursements()
         dataset = dataset.merge(self.__companies(),
                                 how='left',
                                 left_on='cnpj_cpf',
@@ -48,8 +50,9 @@ class Suspicions:
             & dataset['congressperson_id'].notnull()
         return dataset.loc[rows, dataset.notnull().any()]
 
-    def __reimbursements(self):
-        dataset = pd.read_csv(os.path.join(self.data_path, 'reimbursements.xz'),
+    def reimbursements(self):
+        path = os.path.join(self.data_path, 'reimbursements-{}.csv'.format(self.year))
+        dataset = pd.read_csv(path,
                               dtype={'applicant_id': np.str,
                                      'cnpj_cpf': np.str,
                                      'congressperson_id': np.str,
@@ -57,8 +60,6 @@ class Suspicions:
                               low_memory=False)
         dataset['issue_date'] = pd.to_datetime(
             dataset['issue_date'], errors='coerce')
-        dataset = dataset.query('year >= 2016')
-        # dataset = dataset.query('term == 2015')
         return dataset
 
     def __companies(self):


### PR DESCRIPTION
The toolbox changed the external interface a few weeks ago, forcing Whistleblower to depend on a fixed version, outdated.

This pull request removes the version constraint and gets tests passing again.